### PR TITLE
Per file settings

### DIFF
--- a/include/globals.js
+++ b/include/globals.js
@@ -250,7 +250,7 @@ async function LoadSettings() {
     console.log(e);
   }
 
-  tsh_settings = _.defaultsDeep(file_settings, global_settings);
+  tsh_settings = _.defaultsDeep(window.settings, file_settings, global_settings);
   console.log(tsh_settings);
 }
 

--- a/include/globals.js
+++ b/include/globals.js
@@ -251,7 +251,6 @@ async function LoadSettings() {
   }
 
   tsh_settings = _.defaultsDeep(window.settings, file_settings, global_settings);
-  console.log(tsh_settings);
 }
 
 // Registers element for content fitting inside div if the div is resized

--- a/stream_queue/index-multistream.html
+++ b/stream_queue/index-multistream.html
@@ -8,7 +8,7 @@
   <body>
     <div class="stream_queue_content"></div>
     <script>
-      window.config = {
+      window.settings = {
         "stream": "all"
         //option overrides here
       };

--- a/stream_queue/index-stations.html
+++ b/stream_queue/index-stations.html
@@ -8,7 +8,7 @@
   <body>
     <div class="stream_queue_content"></div>
     <script>
-      window.config = {
+      window.settings = {
         "display": {
           "station": true
         }

--- a/stream_queue/index.html
+++ b/stream_queue/index.html
@@ -8,7 +8,7 @@
   <body>
     <div class="stream_queue_content"></div>
     <script>
-      window.config = {
+      window.settings = {
         //option overrides here
       };
     </script>

--- a/stream_queue/index.js
+++ b/stream_queue/index.js
@@ -43,7 +43,6 @@ LoadEverything().then(() => {
     }
 
     assignDefault(config, tsh_settings);
-    assignDefault(config, window_config);
 
     if (!config.display){
         config.display = {};

--- a/stream_queue/next_match.html
+++ b/stream_queue/next_match.html
@@ -8,7 +8,7 @@
   <body>
     <div class="stream_queue_content"></div>
     <script>
-        window.config = {
+        window.settings = {
             display_first_set: false,
             sets_displayed : 1,
             display_stream_name: false

--- a/stream_queue/readme.md
+++ b/stream_queue/readme.md
@@ -18,7 +18,7 @@ The "**queue**" of a stream or station is the list of matches assigned to that s
 
 This layout can display all of these things depending on the following : 
 - If you are tracking a stream or station in TSH directly (using the gear icon next to "Track sets from a stream or station"), this stream or station's queue will be displayed
-- You can also use the options (either in settings.json or `window.config`, see below) : 
+- You can also use the options (either in settings.json or `window.settings`, see below) : 
   - The "stream" option will override the stream selected in TSH : if there is a name between the quotes next to "stream", it will display the queue for that stream no matter what.
   - the "default_stream" option does the opposite : a stream name specified here will be used only if there is no stream selected in TSH.  
 There is no way to display the queue for an arbitrary station, you can only display the station tracked in TSH.
@@ -32,14 +32,14 @@ Note that in global mode, the name of each stream will be displayed : this can b
 ### Options
 Options can be defined in two places : 
 - In settings.json, you will find all the options that can change the behavior or this layout. Remember that everything between the `:` next to an option name, and the next `,` (or `}` at the end) will be the value of that option. Values can be numbers (written normally), text (between quotes) and the two special values `true` and `false`, options that are basically a yes/no question. 
-- You can makes copies of the .html file, while overriding some options for each file. If you want an overlay that displays the global stream queue, and an overlay that follows what TSH is tracking, you'll want to use two separate copies of the HTML files with different options. To override an option only for a specific .html file, open it, and add a `"option name" : value,` line (same syntax as in settings.json) between the brackets after `window.config`. 
+- You can makes copies of the .html file, while overriding some options for each file. If you want an overlay that displays the global stream queue, and an overlay that follows what TSH is tracking, you'll want to use two separate copies of the HTML files with different options. To override an option only for a specific .html file, open it, and add a `"option name" : value,` line (same syntax as in settings.json) between the brackets after `window.settings`. 
   ```html
-    window.config = {
+    window.settings = {
         "OPTION" : VALUE,
     };
   ```
 
-Basically settings.json contains the global options, and if you want to use multiple instances of the layout with different behaviors you copy index.html and use window.config to override the relevant options.  
+Basically settings.json contains the global options, and if you want to use multiple instances of the layout with different behaviors you copy index.html and use window.settings to override the relevant options.  
 
 So, now that you understand options, here are all the possible options and what they do
 

--- a/stream_queue_simple/index.html
+++ b/stream_queue_simple/index.html
@@ -8,7 +8,7 @@
   <body>
     <div class="stream_queue_content"></div>
     <script>
-      window.config = {
+      window.settings = {
         //options overrides here
       };
     </script>

--- a/stream_queue_simple/index.js
+++ b/stream_queue_simple/index.js
@@ -43,7 +43,6 @@ LoadEverything().then(() => {
     }
 
     assignDefault(config, tsh_settings);
-    assignDefault(config, window_config);
 
     if (!config.display){
         config.display = {};

--- a/stream_queue_simple/next_match.html
+++ b/stream_queue_simple/next_match.html
@@ -8,7 +8,7 @@
   <body>
     <div class="stream_queue_content"></div>
     <script>
-      window.config = {
+      window.settings = {
         display_first_set: false,
         sets_displayed : 1,
         display_stream_name: false

--- a/stream_queue_simple/readme.md
+++ b/stream_queue_simple/readme.md
@@ -1,31 +1,45 @@
 ## Stream Queue Layout
+(start.gg only, does no work with Challonge)
 
-A smaller version of the [Stream Queue layout](../stream_queue/readme.md) (`layout/stream_queue/`)
+This layout displays the next matches in the queue for either : 
+- The global stream queue of the tournament (matches on all the streams)
+- A specific stream (selected in TSH or fixed in the config of this layout)
+- A station (selected in TSH)
 
-This layout displays the next matches in the stream queue for the current tournament, either for one specific stream or all streams. Here's how it works.
+Here's how it works.
 
-### Select a stream, or all of them
-But first, what do i mean by "stream" ? Well, a stream is what you define on the top of the "Streams & Stations" page in start.gg. Basically, it's a twitch/youtube/whatever channel that can be assigned to some matches (a stream is assigned to a match = this match will be streamed on that channel). TSH currently only supports twitch channels, so we refer to streams with just the channel name.
+### Select a station, a stream, or all of them
+But first, what do i mean by "stream" and a "station" ?
+A **station** is, in offline tournaments, a litteral station where you play whatever game your event is on (what's important is that each match is played on one station and each station is running one match a ta time) ; each match can be assigned to a station. Stations are registered in the lower part of the "Stream & Stations" page on start.gg. 
+A **stream** is what you define on the top of the "Streams & Stations" page. Basically, it's a twitch/youtube/whatever channel that can be assigned to some matches (a stream is assigned to a match = this match will be streamed on that channel). TSH currently only supports twitch channels, so we refer to streams with just the channel name.  
+Note that you can assign a stream to a station, meaning that any match assigned to that station will be implictly assigned to that stream. A stream can be assigned to multiple stations.  
 
-The layout can either display all the sets in the stream queue (multi-stream mode), or a single stream (single-stream mode). By default, the layout enters single-stream mode as long as a stream name is specified somewhere : 
-- If you enter a stream name in TSH directly (using the gear icon next to "Load current set from stream"), this stream will be used
-- You can also use the options (either in settings.json or `window.config`, see below) : 
-  - The "stream" option will override the stream selected in TSH : if there is a name between the quotes next to "stream", it will be used no matter what.
-  - the "default_stream" option does the opposite : a stream name specified here will be used only if there is no stream selected in TSH.
+The "**queue**" of a stream or station is the list of matches assigned to that stream or station. The "stream queue" of the tournament is all the streamed sets for all the streams registered and can be viewed in the "Stream Queue" page.  
 
-If you do this, the layout will only display sets assigned to the stream you gave, if you don't give a stream anywhere (or use the "force_multistream" option, see below), all sets in the stream queue will be displayed.
+This layout can display all of these things depending on the following : 
+- If you are tracking a stream or station in TSH directly (using the gear icon next to "Track sets from a stream or station"), this stream or station's queue will be displayed
+- You can also use the options (either in settings.json or `window.settings`, see below) : 
+  - The "stream" option will override the stream selected in TSH : if there is a name between the quotes next to "stream", it will display the queue for that stream no matter what.
+  - the "default_stream" option does the opposite : a stream name specified here will be used only if there is no stream selected in TSH.  
+There is no way to display the queue for an arbitrary station, you can only display the station tracked in TSH.
 
-Note that in multistream mode, the names of the streams will be displayed : this can be changed using [options](#options)
+If you do not specify a stream or station anywhere (nothing in the options and nothing tracked in TSH), the layout will enter global mode, and display sets for the global stream queue.  
+
+Note that in global mode, the name of each stream will be displayed : this can be changed using the [options](#options)  
+
+![Missing Image](./index-multistream_preview.png)
 
 ### Options
 Options can be defined in two places : 
 - In settings.json, you will find all the options that can change the behavior or this layout. Remember that everything between the `:` next to an option name, and the next `,` (or `}` at the end) will be the value of that option. Values can be numbers (written normally), text (between quotes) and the two special values `true` and `false`, options that are basically a yes/no question. 
-- You can makes copies of the .html file, while overriding some options for each file. If you want an overlay that displays all the stream queue, and an overlay that focuses on a specific stream, that's what you want. To override an option only for a specific .html file, open it, and add a `"option name" : value,` line (same syntax as in settings.json) between the brackets after `window.config`. 
+- You can makes copies of the .html file, while overriding some options for each file. If you want an overlay that displays the global stream queue, and an overlay that follows what TSH is tracking, you'll want to use two separate copies of the HTML files with different options. To override an option only for a specific .html file, open it, and add a `"option name" : value,` line (same syntax as in settings.json) between the brackets after `window.settings`. 
   ```html
-    window.config = {
+    window.settings = {
         "OPTION" : VALUE,
     };
   ```
+
+Basically settings.json contains the global options, and if you want to use multiple instances of the layout with different behaviors you copy index.html and use window.settings to override the relevant options.  
 
 So, now that you understand options, here are all the possible options and what they do
 
@@ -33,15 +47,16 @@ So, now that you understand options, here are all the possible options and what 
 | - | -
 | stream | see above
 | default_stream | see above
-| force_multistream | If `true`, the layout will always be in multi-stream mode.
-| display_stream_name | If the value is "multistream", the name of the streams will be displayed but only in multi-stream mode. If `true`, it will be here even in single-stream mode. If `false`, never.
+| force_multistream | If `true`, the layout will always be in global mode.
+| display_stream_name | If the value is "multistream", the name of the streams will be displayed but only in global mode. If `true`, it will be here even when displaying only one stream. If `false`, never.
 | sets_displayed | How many sets are displayed. If -1, no limit, all sets in the queue are displayed, if 0 or more only the first x sets will be listed. 
 | display_first_set | if `false`, the first set in the queue will be skipped. Why would you want that ? Well, when a set is started, it stays in the queue, so you may want to only have future sets. 
-| station | Remember the start.gg "streams & stations" page ? On this page, you can also defines "station", which are just the console/pc + screen setups where matches are played (which we usually just refer to as "setups"). A station can be assigned to a match so players can see where they are playing/gonna play, but you can also assign a stream to a station, meaning that matches on this station are also streamed on that stream. And you can assign multiple stations to a single stream (if you want to stream multiple matches at the same time). So, this options allows you to limit the display to one specific station. If the value is 2, and stations 1, 2 and 3 are assigned to a stream, the matches assigned to stations 1 and 3 will not show up, even if they are also in the stream queue (and on the same stream). God that was a long explanation.
+| minimum_dtermined_players | Sets might have "indermined" players (basically, if you added a set to the stream queue before 2 players qualified for this set). This option limits the display to only sets with a minimum number of players qualified. 2 means only display sets where we know who both players are, 0 means display everything. If the value is below 2, players that aren't determined yet will appear as a big "TBD" (To Be Determined) in the layout.
+| station | Remember how you can assign a *station* to a *stream* ? When that's been done for your stream, you can limit the display to only one station. If the value is 2, and stations 1, 2 and 3 are assigned to the stream displayed currently, the matches assigned to stations 1 and 3 will not show up, despite being in the queue for the displayed stream.  *Note : this is different from displaying the queue for a station by tracking that station in TSH. Basically, TSH only pulls the queues for all streams and the station tracked in TSH. If you want to display the station tracked in TSH, it will work even if not streamed. If you use this option, you can target an arbitrary station without tracking it in TSH, but it has to be assigned to a stream, and you need to select that stream using the options.*
 | display | This one is special, it's not actually a property, but rather a group of properties. So, you don't change it's value directly (what comes after the : next to "display"), you change the sub-properties inside the brackets next to "display". All these sub-properties are true or false and control whether something is displayed. 
 | display.avatar | The player's start.gg avatar.
 | display.country_flag | The flag of each player's countries
 | display.state_flag | The flag of each player's state/region
-| display.match | The match. If not displayed, it will be replaced by a big "VS"
+| display.station | The station assigned to this set. 
 
-Is there something you don't understand ? A problem with the layout ? Message @TwilCynder on twitter.
+Is there something you don't understand ? A problem with the layout ? Message [@TwilCynder](https://twitter.com/TwilCynder) on twitter or join [TSH's Discord Server](https://discord.gg/X9Sp2FkcHF)


### PR DESCRIPTION
Take settings from `window.settings` as well as the settings.json files, priorizing `windows.settings`, so you can override settings for each html file.

```html
<script>
    window.settings = {
       "automatic_theme": true
    }
</script>
```

This was already implemented for the stream queue layouts, so I removed the feature in these layouts since it's now redundant