### PR TITLE
First pitch of 2XKO Scoreboard layout

### DIFF
--- a/scoreboard_2xko/index.css
+++ b/scoreboard_2xko/index.css
@@ -1,0 +1,797 @@
+@font-face {
+  font-family: "NotoSans";
+  src: url("../include/NotoSans-Regular.ttf") format("truetype");
+}
+
+@font-face {
+  font-family: "RobotoCondensed";
+  src: url("../include/RobotoCondensed.ttf") format("truetype");
+}
+
+@font-face {
+  font-family: "Roboto";
+  src: url("../include/Roboto-Regular.ttf") format("truetype");
+}
+
+body {
+  font-family: var(--font);
+  font-weight: bold;
+  opacity: 0;
+  overflow: hidden;
+  margin: 0;
+  width: 1920px;
+  height: 1080px;
+  filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.12))
+    drop-shadow(0 3px 1px rgba(0, 0, 0, 0.14))
+    drop-shadow(0 1px 5px rgba(0, 0, 0, 0.12))
+    drop-shadow(0 -1px 2px rgba(0, 0, 0, 0.1));
+  letter-spacing: 1;
+  background-size: cover;
+}
+
+.anim_container_outer {
+  position: absolute;
+  overflow: hidden;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 1920px;
+  height: 1080px;
+}
+
+.anim_container_inner {
+  position: absolute;
+  overflow: hidden;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 1920px;
+  height: 1080px;
+}
+
+.container {
+  position: absolute;
+  color: var(--text-color);
+  overflow: hidden;
+  display: flex;
+  box-sizing: border-box;
+  border-radius: var(--border-radius);
+  background: var(--bg-color);
+  align-items: center;
+}
+
+.player.container {
+  width: 500px;
+  height: 64px;
+  top: 42px;
+  padding: 0px 6px;
+}
+
+.player.container > div:not(.score) > .text:not(.text_empty) {
+  margin-left: 4px;
+  margin-right: 4px;
+}
+
+.fgc .player.container {
+  top: 8px;
+  width: 652px;
+}
+
+.twoxko .player.container {
+  top: 10px;
+  height: 48px;
+  width: 348px;
+  transform: skewX(12deg);
+  border-radius: calc(var(--border-radius) / 2);
+  padding: 0px 16px;
+}
+
+.twoxko .p2.player.container > div:not(.score) {
+  transform: skewX(12deg);
+}
+
+.twoxko .p1.player.container > div:not(.score) {
+  transform: skewX(-12deg);
+}
+
+.p1.container {
+  background-position: 100% 0;
+  left: 380px;
+  flex-direction: row;
+}
+
+.fgc .p1.container {
+  left: 154px;
+}
+
+.twoxko .p1.container {
+  left: 434px;
+}
+
+.p2.container {
+  background-position: 0 0;
+  right: 380px;
+  flex-direction: row-reverse;
+}
+
+.fgc .p2.container {
+  right: 154px;
+}
+
+.twoxko .p2.container {
+  transform: skewX(-12deg);
+  right: 434px;
+}
+
+.name,
+.name_twitter {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  overflow: hidden;
+  justify-content: center;
+  padding-left: 8px;
+  padding-right: 8px;
+  box-sizing: border-box;
+  max-width: 100%;
+  font-size: 30px;
+}
+
+.chips {
+  display: flex;
+  position: absolute;
+  top: 112px;
+  width: 500px;
+  height: 24px;
+  justify-content: right;
+  align-content: center;
+  overflow: hidden;
+}
+
+.twoxko .chips {
+  top: 106px;
+  height: 32px;
+}
+
+.chip {
+  overflow: hidden;
+  border-radius: calc(var(--border-radius) / 2);
+}
+
+.p1.chips {
+  left: 380px;
+}
+
+.twoxko .chip {
+  height: 32px;
+}
+
+.twoxko .p1.chips {
+  left:172px;
+  margin-top:30px;
+  justify-content: right;
+  max-width:257px;
+  width:257px;
+}
+
+.p2.chips {
+  flex-direction: row-reverse;
+  left: 1040px;
+  justify-content: left;
+}
+
+.twoxko .p2.chips {
+  margin-top:30px;
+  max-width:257px;
+  width:257px;
+  left:unset;
+  right: 172px;
+  justify-content: right;
+}
+
+.chip .text:not(.text_empty) {
+  margin-left: 4px;
+  margin-right: 4px;
+  height: 24px;
+  font-size: 18px;
+  padding-left: 12px;
+  padding-right: 12px;
+  background: var(--bg-color);
+  color: var(--text-color);
+  border-radius: calc(var(--border-radius) / 4);
+  min-width: unset;
+  padding-left: 8px;
+  padding-right: 8px;
+}
+
+.twoxko .p2 .chip .text:not(.text_empty)::before {
+  transform: skewX(-12deg);
+}
+
+.twoxko .chip .text:not(.text_empty) {
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.twoxko .chip .text {
+  background: none;
+  position: relative;
+}
+
+.twoxko .chip .text:not(.text_empty)::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: calc(100% + 4px);
+  height: 100%;
+  background: var(--bg-color);
+  border-radius: calc(var(--border-radius) / 4);
+  transform: skewX(12deg);
+  content: " ";
+  z-index: -999;
+}
+
+.twoxko .p2 .chip .text:not(.text_empty)::before {
+  transform: skewX(-12deg);
+}
+
+.flagcountry, .flagstate {
+  display: flex;
+  justify-content: center;
+}
+
+.flagstate .text,
+.flagcountry .text {
+  display: flex;
+  gap: 8px;
+  overflow: hidden;
+}
+
+.p2 .flagstate .text,
+.p2 .flagcountry .text {
+  flex-direction: row-reverse;
+}
+
+.fgc .flagcountry .text,
+.fgc .flagstate .text {
+  flex-direction: column;
+  gap: 0;
+  letter-spacing: 2px;
+  font-size: 18px;
+}
+
+.twoxko .chip .text:not(.text_empty) {
+  font-size: 20px;
+  height: 100%;
+}
+
+.fgc .name_twitter {
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.fgc .p2 .name_twitter {
+  flex-direction: row-reverse;
+}
+
+.name_twitter .name {
+  font-size: 32px;
+}
+
+.fgc .name_twitter .name {
+  width: 60%;
+}
+
+.twoxko .name_twitter .name {
+  width: 100%;
+  font-size: 30px;
+}
+
+.fgc .p1 .name_twitter .name .text {
+  justify-content: flex-start;
+}
+
+.fgc .p2 .name_twitter .name .text {
+  justify-content: flex-end;
+}
+
+.twoxko .p1 .name_twitter, .twoxko .p1 .score > .text {
+  transform: skewX(-12deg);
+}
+
+.twoxko .p2 .name_twitter, .twoxko .p2 .score > .text {
+  transform: skewX(12deg);
+}
+
+.name_twitter {
+  max-width: 100%;
+}
+
+.name_twitter .extra {
+  display: flex;
+  justify-content: center;
+  width: 40%;
+  font-size: 18px;
+  overflow: hidden;
+}
+
+.p2 .extra {
+  flex-direction: row-reverse;
+}
+
+.fgc .name_twitter .extra {
+  flex-direction: column;
+}
+
+.name_twitter .twitter {
+  font-size: 18px;
+  max-width: 100%;
+}
+
+.full_team {
+  font-size: 18px;
+  max-width: 100%;
+}
+
+.extra .pronoun {
+  width: 100%;
+}
+
+.fgc .p1 .name_twitter .twitter .text {
+  justify-content: flex-end;
+}
+
+.fgc .p2 .name_twitter .twitter .full_team .text {
+  justify-content: flex-start;
+}
+
+.fgc .p1 .name_twitter .pronoun .text {
+  justify-content: flex-end;
+}
+
+.fgc .p2 .name_twitter .pronoun .text {
+  justify-content: flex-start;
+}
+
+.twitter_logo {
+  -webkit-mask-image: url(./twitter.svg);
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  background: var(--text-color);
+  width: 18px;
+  height: 18px;
+  margin-right: 8px;
+}
+
+.chips .twitter_logo {
+  margin-left: -4px;
+}
+
+.light .twitter_logo {
+  filter: invert(1);
+}
+
+.logo {
+  position: absolute;
+  top: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100px;
+  height: 100px;
+  background-image: url("../logo.png");
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  border-radius: var(--border-radius);
+  z-index: 9;
+}
+
+.fgc .logo {
+  top: 145px;
+  width: 120px;
+  height: 120px;
+}
+
+.twoxko .logo {
+  width: 80px;
+  height: 80px;
+  top: 924px;
+}
+
+.info.container {
+  left: 50%;
+  padding-left: 20px;
+  padding-right: 20px;
+  background-position: center;
+  text-transform: uppercase;
+  box-sizing: border-box;
+  font-size: 20px;
+}
+
+.info.container_inner {
+  display: flex;
+  width: 100%;
+  font-size: inherit;
+  justify-content: space-around;
+}
+
+.info.container_inner > div {
+  flex-shrink: 0;
+  text-align: center;
+}
+
+.info.container.top {
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 199px;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+  height: 36px;
+  padding: 8px 16px;
+}
+
+.tournament_name {
+  font-size: 22px;
+  width: 100%;
+  height: 100%;
+}
+
+.twoxko .tournament_name {
+  height: unset;
+  font-size: 24px;
+}
+
+.fgc .info.container.top {
+  top: 8px;
+  height: 34px;
+  width: 290px;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: calc(var(--border-radius) / 2);
+  justify-content: center;
+}
+
+.twoxko .info.container.top {
+  background: unset;
+  overflow: visible;
+  justify-content: center;
+  padding: 0 42px;
+  width: 340px;
+  top: 0;
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+  height: 46px;
+}
+
+.info.container.bottom {
+  top: 42px;
+  left: 42px;
+  display: flex;
+  justify-content: center;
+  height: unset;
+  flex-direction: column;
+  width: 280px;
+  height: 64px;
+  font-size: 20px;
+  padding: 4px 16px;
+}
+
+.info.container.right {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  width: 280px;
+  height: 64px;
+  font-size: 20px;
+  padding: 4px 16px;
+}
+
+.info.container.left {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  width: 280px;
+  height: 64px;
+  font-size: 20px;
+  padding: 4px 16px;
+}
+
+.phase {
+  font-size: 18px;
+  letter-spacing: 3px;
+  width: 100%;
+}
+
+.twoxko .phase {
+  font-size: 20px;
+  letter-spacing: 2px;
+}
+
+.match {
+  font-size: 24px;
+  letter-spacing: 2px;
+  width: 100%;
+}
+
+.twoxko .match {
+  font-size: 26px;
+  letter-spacing: 2px;
+}
+
+.fgc .info.container.bottom {
+  top: unset;
+  bottom: 0;
+  padding: 16px 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.twoxko .info.container.bottom {
+  border-radius: calc(var(--border-radius) / 2);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  top: unset;
+  bottom: 0;
+  width: 400px;
+  height: 64px;
+  background: unset;
+  overflow: visible;
+  padding: 0 42px;
+  justify-content: center;
+}
+
+.icon {
+  display: flex;
+  justify-content: center;
+}
+
+.icon .text:not(.text_empty) {
+  flex-shrink: 0;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
+.icon div:not(.text) {
+  width: 48px;
+  height: 48px;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-color: #3f3f46;
+  border-radius: var(--border-radius);
+}
+
+.tsh_character {
+  background-color: #3f3f46;
+  border-radius: var(--border-radius);
+  overflow: hidden;
+}
+
+.icon div:not(.text) {
+  border-radius: calc(var(--border-radius) * 2 / 3);
+}
+
+.twoxko .icon div:not(.text) {
+  height: 34px;
+  width: 34px;
+}
+
+.flags_container {
+  display: flex;
+  flex-direction: column;
+}
+
+.flag {
+  display: inline-block;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+  width: 32px;
+  height: 24px;
+}
+
+.fgc .flag {
+  width: 28px;
+  height: 18px;
+}
+
+.sponsor_icon > div > div {
+  display: inline-block;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  width: 48px;
+  height: 48px;
+  border-radius: var(--border-radius);
+}
+
+.fgc .sponsor_icon {
+  position: absolute;
+  right: 200px;
+  z-index: -999;
+  opacity: 0.6;
+}
+
+.fgc .p2 .sponsor_icon {
+  right: unset;
+  left: 200px;
+}
+
+.fgc .sponsor_icon > div > div {
+  width: 80px;
+  height: 80px;
+}
+
+.twoxko .sponsor_icon {
+  position: absolute;
+  right: 90px;
+  z-index: -999;
+  opacity: 0.6;
+}
+
+.twoxko .p2 .sponsor_icon {
+  right: unset;
+  left: 90px;
+}
+
+.twoxko .sponsor_icon > div > div {
+  width: 100px;
+  height: 100px;
+}
+
+.character_container {
+  display: flex;
+  overflow: hidden;
+  height: 100%;
+  flex-shrink: 0;
+  width: auto;
+  align-items: center;
+  gap: 4px;
+}
+
+.character_container > div {
+  overflow: hidden;
+  height: 48px;
+  width: 48px;
+}
+
+.character_container > div > div {
+  overflow: hidden;
+  height: 48px;
+  display: flex;
+  align-items: center;
+}
+
+.score {
+  width: 64px;
+  height: 64px;
+  font-size: 40px;
+  color: var(--bg-color);
+  flex-grow: 0;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.twoxko .score {
+  font-size: 34px;
+}
+
+.p1 .score {
+  color: var(--p1-score-color);
+  background: var(--p1-score-bg-color);
+  margin-right: -6px;
+  margin-left: 6px;
+}
+
+.twoxko .p1 .score {
+  margin-right: -16px;
+  margin-left: 16px;
+}
+
+.sponsor {
+  margin-right: 6px;
+}
+
+.p1 .sponsor {
+  color: var(--p1-sponsor-color);
+}
+
+.p2 .score {
+  color: var(--p2-score-color);
+  background: var(--p2-score-bg-color);
+  margin-left: -6px;
+  margin-right: 6px;
+}
+
+.twoxko .p2 .score {
+  margin-left: -16px;
+  margin-right: 16px;
+}
+
+.p2 .sponsor {
+  color: var(--p2-sponsor-color);
+}
+
+.losers {
+  display: inline-flex;
+  width: 22px;
+  height: 22px;
+  font-size: 18px;
+  border-radius: 100%;
+  text-align: center;
+  align-items: center;
+  justify-content: center;
+  margin: 0 6px;
+}
+
+.p1 .losers {
+  background: #ff3837ff;
+}
+
+.p2 .losers {
+  background: #308affff;
+}
+
+.top_bg_1, .top_bg_2, .bottom_bg_1, .bottom_bg_2 {
+  background: var(--bg-color);
+  position: fixed;
+  width: 60%;
+  height: 100%;
+  top: 0;
+  z-index: -1;
+  border-radius: calc(var(--border-radius) / 2);
+  overflow: hidden;
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.bottom_bg_1, .bottom_bg_2 {
+  bottom: 0;
+  border-radius: calc(var(--border-radius) / 2);
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.top_bg_1 {
+  transform: skewX(45deg);
+  transform-origin: top right;
+  left: 0;
+}
+
+.twoxko .top_bg_1 {
+  transform: skewX(12deg);
+}
+
+.top_bg_2 {
+  transform: skewX(-45deg);
+  transform-origin: top left;
+  right: 0;
+}
+
+.twoxko .top_bg_2 {
+  transform: skewX(-12deg);
+}
+
+.bottom_bg_1 {
+  transform: skewX(45deg);
+  transform-origin: bottom right;
+  right: 0;
+}
+
+.twoxko .bottom_bg_1 {
+  transform: skewX(12deg);
+}
+
+.bottom_bg_2 {
+  transform: skewX(-45deg);
+  transform-origin: bottom left;
+  left: 0;
+}
+
+.twoxko .bottom_bg_2 {
+  transform: skewX(-12deg);
+}

--- a/scoreboard_2xko/index.html
+++ b/scoreboard_2xko/index.html
@@ -1,0 +1,63 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="../include/globals.js"></script>
+    <link rel="stylesheet" href="../main.css" />
+    <link rel="stylesheet" href="./index.css" />
+  </head>
+  <body class="fgc twoxko">
+    <div class="anim_container_outer">
+      <div class="anim_container_inner">
+        <div class="info top container fade_down">
+          <div class="top_bg_1"></div>
+          <div class="top_bg_2"></div>
+          <div class="match"></div>
+        </div>
+
+        <div class="p1 player container fade_right">
+          <div class="icon avatar"></div>
+          <div class="icon online_avatar"></div>
+          <div class="flagcountry"></div>
+          <div class="flagstate"></div>
+          <div class="sponsor_icon"></div>
+          <div class="name_twitter">
+            <div class="name"></div>
+          </div>
+          <div class="score"></div>
+        </div>
+        <div class="p2 player container fade_left">
+          <div class="icon avatar"></div>
+          <div class="icon online_avatar"></div>
+          <div class="flagcountry"></div>
+          <div class="flagstate"></div>
+          <div class="sponsor_icon"></div>
+          <div class="name_twitter">
+            <div class="name"></div>
+          </div>
+          <div class="score"></div>
+        </div>
+
+        <div class="info bottom container fade_up">
+          <div class="bottom_bg_1"></div>
+          <div class="bottom_bg_2"></div>
+          <div class="tournament_name"></div>
+          <div class="phase"></div>
+        </div>
+
+        <div class="p1 chips">
+          <div class="full_team chip fade_stagger_reverse"></div>
+          <div class="twitter chip fade_stagger_reverse"></div>
+          <div class="pronoun chip fade_stagger_reverse"></div>
+        </div>
+
+        <div class="p2 chips">
+          <div class="full_team chip fade_stagger_reverse"></div>
+          <div class="twitter chip fade_stagger_reverse"></div>
+          <div class="pronoun chip fade_stagger_reverse"></div>
+        </div>
+      </div>
+    </div>
+
+    <script src="index.js"></script>
+  </body>
+</html>

--- a/scoreboard_2xko/index.js
+++ b/scoreboard_2xko/index.js
@@ -1,0 +1,370 @@
+LoadEverything().then(() => {
+  
+  gsap.config({ nullTargetWarn: false, trialWarn: false });
+
+  let startingAnimation = gsap
+    .timeline({ paused: true })
+    .from(
+      [".fade"],
+      {
+        duration: 0.2,
+        autoAlpha: 0,
+        ease: "power2.out",
+      },
+      0
+    )
+    .from(
+      [".fade_down_left_stagger:not(.text_empty)"],
+      {
+        autoAlpha: 0,
+        stagger: {
+          each: 0.05,
+          from: 'end',
+          opacity: 0,
+          y: "-20px",
+        },
+        duration: 0.2,
+      },
+      0
+    )
+    .from(
+      [".fade_down_right_stagger:not(.text_empty)"],
+      {
+        autoAlpha: 0,
+        stagger: {
+          each: 0.05,
+          from: 'end',
+          opacity: 0,
+          y: "-20px",
+        },
+        duration: 0.2,
+      },
+      0
+    )
+    .from(
+      [".p1 .fade_stagger:not(.text_empty)"],
+      {
+        autoAlpha: 0,
+        stagger: {
+          each: 0.05,
+          from: 'end',
+          opacity: 0,
+        },
+        duration: 0.2,
+      },
+      0
+    )
+    .from(
+      [".p2 .fade_stagger:not(.text_empty)"],
+      {
+        autoAlpha: 0,
+        stagger: {
+          each: 0.05,
+          from: 'end',
+          opacity: 0,
+        },
+        duration: 0.2,
+      },
+      0
+    )
+    .from(
+      [".p1 .fade_stagger_reverse:not(.text_empty)"],
+      {
+        autoAlpha: 0,
+        stagger: {
+          each: 0.05,
+          from: 'start',
+          opacity: 0,
+        },
+        duration: 0.2,
+      },
+      0
+    )
+    .from(
+      [".p2 .fade_stagger_reverse:not(.text_empty)"],
+      {
+        autoAlpha: 0,
+        stagger: {
+          each: 0.05,
+          from: 'start',
+          opacity: 0,
+        },
+        duration: 0.2,
+      },
+      0
+    )
+    .from(
+      [".fade_right_stagger:not(.text_empty)"],
+      {
+        autoAlpha: 0,
+        stagger: {
+          each: 0.05,
+          from: 'end',
+          opacity: 0,
+        },
+        duration: 0.2,
+      },
+      0
+    )
+    .from(
+      [".fade_down"],
+      {
+        duration: 0.2,
+        y: "-20px",
+        ease: "power2.out",
+        autoAlpha: 0,
+      },
+      0
+    )
+    .from(
+      [".fade_right"],
+      {
+        duration: 0.2,
+        x: "-20px",
+        ease: "power2.out",
+        autoAlpha: 0,
+      },
+      0
+    )
+    .from(
+      [".fade_left"],
+      {
+        duration: 0.2,
+        x: "+20px",
+        ease: "power2.out",
+        autoAlpha: 0,
+      },
+      0
+    )
+    .from(
+      [".fade_up"],
+      {
+        duration: 0.2,
+        y: "+20px",
+        ease: "power2.out",
+        autoAlpha: 0,
+      },
+      0
+    )
+
+  Start = async () => {
+    startingAnimation.restart();
+  };
+
+  Update = async (event) => {
+    let data = event.data;
+    let oldData = event.oldData;
+
+    let isTeams = Object.keys(data.score[window.scoreboardNumber].team["1"].player).length > 1;
+
+    for (const [t, team] of [
+      data.score[window.scoreboardNumber].team["1"],
+      data.score[window.scoreboardNumber].team["2"],
+    ].entries()) {
+      let names = [];
+      for (const [p, player] of Object.values(team.player).entries()) {
+        if (player && player.name) {
+          names.push(await Transcript(player.name));
+        }
+      }
+      let isARealTeam = names.length > 1;
+      if(!isARealTeam) {
+        // We are going to assume that if there is one player with a name in the team, this is the player we want.
+        // If there are two or none, we're taking the first one.
+        // There is no proper implentation of a mixed mode in TSH as of making this.
+        let playerToUse = team.player["1"];
+
+        if(!team.player["1"].name && team.player["2"].name) {
+          playerToUse = team.player["2"];
+        }
+        for (const [p, player] of [playerToUse].entries()) {
+          if (player) {
+            SetInnerHtml(
+              $(`.p${t + 1}.container .name`),
+              `
+                <span class="sponsor">
+                  ${player.team ? player.team : ""}
+                </span>
+                ${await Transcript(player.name)}
+                ${team.losers ? "<span class='losers'>L</span>" : ""}
+              `
+            );
+
+            SetInnerHtml(
+              $(`.p${t + 1} .flagcountry`),
+              player.country.asset
+                ? `
+                  <div class='flag' style='background-image: url(../../${player.country.asset.toLowerCase()})'></div>
+                  <div>${player.country.code}</div>
+                `
+                : ""
+            );
+
+            SetInnerHtml(
+              $(`.p${t + 1} .flagstate`),
+              player.state.asset
+                ? `
+                  <div class='flag' style='background-image: url(../../${player.state.asset})'></div>
+                  <div>${player.state.code}</div>
+                `
+                : ""
+            );
+
+            await CharacterDisplay(
+              $(`.p${t + 1}.container .character_container`),
+              {
+                asset_key: "base_files/icon",
+                source: `score.${window.scoreboardNumber}.team.${t + 1}`,
+                scale_fill_x: true,
+                scale_fill_y: true,
+                custom_zoom: 1.0
+              },
+              event
+            );
+
+            SetInnerHtml(
+              $(`.p${t + 1}.container .sponsor_icon`),
+              player.sponsor_logo
+                ? `<div style="background-image: url('../../${player.sponsor_logo}')"></div>`
+                : ""
+            );
+
+            SetInnerHtml(
+              $(`.p${t + 1}.container .avatar`),
+              player.avatar
+                ? `<div style="background-image: url('../../${player.avatar}')"></div>`
+                : ""
+            );
+
+            SetInnerHtml(
+              $(`.p${t + 1}.container .online_avatar`),
+              player.online_avatar
+                ? `<div style="background-image: url('${player.online_avatar}')"></div>`
+                : ""
+            );
+
+            SetInnerHtml(
+              $(`.p${t + 1} .twitter`),
+              player.twitter
+                ? `<span class="twitter_logo"></span>${String(player.twitter)}`
+                : ""
+            );
+
+            SetInnerHtml(
+              $(`.p${t + 1} .pronoun`),
+              player.pronoun ? player.pronoun : ""
+            );
+
+            SetInnerHtml($(`.p${t + 1} .full_team`), 
+              ""
+            );
+
+
+            SetInnerHtml(
+              $(`.p${t + 1} .seed`),
+              player.seed ? `Seed ${player.seed}` : ""
+            );
+
+            SetInnerHtml($(`.p${t + 1}.container .score`), String(team.score));
+
+            SetInnerHtml(
+              $(`.p${t + 1}.container .sponsor-container`),
+              `<div class='sponsor-logo' style="background-image: url('../../${player.sponsor_logo}')"></div>`
+            );
+
+            if ($(".sf6.online").length > 0) {
+              console.log(player.twitter);
+              console.log(player.pronoun);
+              if (!player.twitter && !player.pronoun) {
+                gsap.to($(`.p${t + 1}.chips`), { autoAlpha: 0 });
+              } else {
+                gsap.to($(`.p${t + 1}.chips`), { autoAlpha: 1 });
+              }
+            }
+          }
+        }
+        if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
+          document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
+        }
+      } else {
+        let teamName = team.teamName;
+
+        let names = [];
+        for (const [p, player] of Object.values(team.player).entries()) {
+          if (player && player.name) {
+            names.push(await Transcript(player.name));
+          }
+        }
+        let isARealTeam = names.length > 1;
+        let playerNames = names.join(" / ");
+
+        if (!isARealTeam || !team.teamName || team.teamName == "") {
+          teamName = playerNames;
+        }
+
+        SetInnerHtml(
+          $(`.p${t + 1}.container .name`),
+          `
+            ${teamName}
+            ${team.losers ? "<span class='losers'>L</span>" : ""}
+          `
+        );
+
+        SetInnerHtml($(`.p${t + 1} .flagcountry`), "");
+
+        SetInnerHtml($(`.p${t + 1} .flagstate`), "");
+
+        await CharacterDisplay(
+          $(`.p${t + 1}.container .character_container`),
+          {
+            asset_key: "base_files/icon",
+            source: `score.${window.scoreboardNumber}.team.${t + 1}`,
+            slice_character: [0, 1],
+            scale_fill_x: true,
+            scale_fill_y: true,
+            custom_zoom: 1.0
+          },
+          event
+        );
+
+        SetInnerHtml($(`.p${t + 1}.container .sponsor_icon`), "");
+
+        SetInnerHtml($(`.p${t + 1}.container .avatar`), "");
+
+        SetInnerHtml($(`.p${t + 1}.container .online_avatar`), "");
+
+        SetInnerHtml($(`.p${t + 1} .full_team`), 
+          teamName != playerNames ? playerNames : ""
+        );
+
+        SetInnerHtml(
+          $(`.p${t + 1} .twitter`),
+          ""
+        );
+
+        SetInnerHtml(
+          $(`.p${t + 1} .pronoun`),
+          ""
+        );
+
+        SetInnerHtml($(`.p${t + 1}.container .score`), String(team.score));
+
+        SetInnerHtml($(`.p${t + 1}.container .sponsor-container`), "");
+
+        if(team.color) {
+          document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
+        }
+      }
+    }
+
+    SetInnerHtml($(".tournament_name"), data.tournamentInfo.tournamentName);
+
+    SetInnerHtml($(".match"), data.score[window.scoreboardNumber].match);
+
+    let phaseTexts = [];
+    if (data.score[window.scoreboardNumber].phase) phaseTexts.push(data.score[window.scoreboardNumber].phase);
+    if (data.score[window.scoreboardNumber].best_of_text) phaseTexts.push(data.score[window.scoreboardNumber].best_of_text);
+
+    SetInnerHtml($(".phase"), phaseTexts.join(" - "));
+  };
+});

--- a/scoreboard_2xko/twitter.svg
+++ b/scoreboard_2xko/twitter.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   aria-hidden="true"
+   focusable="false"
+   data-prefix="fab"
+   data-icon="twitter"
+   class="svg-inline--fa fa-twitter fa-w-16"
+   role="img"
+   viewBox="0 0 512 512"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="twitter.svg"
+   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="0.9765625"
+     inkscape:cx="253.952"
+     inkscape:cy="256.512"
+     inkscape:window-width="1366"
+     inkscape:window-height="683"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     fill="currentColor"
+     d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"
+     id="path2"
+     style="fill:#ffffff" />
+</svg>


### PR DESCRIPTION
Hello!

I've created a first implementation of a scoreboard for 2XKO! It is based off the existing "SF6 Offline" scoreboard!
It is in his own folder as suggested by Mathias as there is a twist in how teams are working due to the nature of 2xko.

2xko can be played in 1v1, 2v2 as well as 1v2, as of making this, TSH does not have an implementation for that new mixed mode. Therefore, it is using the regular team mode with some behavior changes in the javascript file.

If only one player is in a team, a solo player layout will be used and the player's twitter and pronouns may be shown if available. It will default on the first player slot, but if the first player name is empty but the second isn't, it'll use that slot instead.
If two players are in a team, then it will try to show the team name if there is one otherwise show the merged names in the "Player A / Player B" format. However, if a team name is used, a chip will appear at the bottom of the health bar showing the merged names.

I am more of a back-end developer than a front-end developer, and the 2xko layout doesn't have much space. I am more than happy to offer a starting point and am open to anyone willing to improve it or optimize the CSS :) 

# Some screenshots
**2 solo players**
<img width="1721" height="974" alt="image" src="https://github.com/user-attachments/assets/9d4bea71-c0b2-471e-a309-0ab46d3100a6" />

**A team without a name against a solo player**
<img width="1720" height="972" alt="image" src="https://github.com/user-attachments/assets/30ce88d1-2fc3-453a-9084-9ec7a033f1a1" />

**A team with a name against a solo player**
<img width="1724" height="975" alt="image" src="https://github.com/user-attachments/assets/31251666-e0cb-457c-8bcf-4d4647c33468" />

**Two teams with a name**
<img width="1726" height="974" alt="image" src="https://github.com/user-attachments/assets/1a918294-2ac4-45a0-afb6-88f19718054b" />
