### PR TITLE
Remove redundant script includes

### DIFF
--- a/commentators/tag_name_twitter.html
+++ b/commentators/tag_name_twitter.html
@@ -2,9 +2,6 @@
   <head>
     <meta charset="utf-8" />
     <script src="../include/globals.js"></script>
-    <script src="../include/gsap.min.js"></script>
-    <script src="../include/he.js"></script>
-    <script src="../include/jquery-3.6.0.min.js"></script>
     <link rel="stylesheet" href="../main.css" />
     <link rel="stylesheet" href="./index.css" />
   </head>

--- a/scoreboard/arms.html
+++ b/scoreboard/arms.html
@@ -1,9 +1,6 @@
 <html>
   <head>
     <script src="../include/globals.js"></script>
-    <script src="../include/gsap.min.js"></script>
-    <script src="../include/he.js"></script>
-    <script src="../include/jquery-3.6.0.min.js"></script>
     <link rel="stylesheet" href="../main.css" />
     <link rel="stylesheet" href="./index.css" />
   </head>


### PR DESCRIPTION
Some html files were not updated following the change that made globals.js include all libs (jquery, gsap, etc) itself and still included them directly. I removed these includes. Another two-lines inconsequential PR but this was stressing me out