### PR TITLE
Include alternate scaling text mode where font size is reduced

### DIFF
--- a/include/globals.js
+++ b/include/globals.js
@@ -326,10 +326,14 @@ function FitText(target) {
         window.getComputedStyle(textElement[0]).fontSize
       );
 
-      const ratio = target.width() / textElement[0].scrollWidth;
+      let fontSize = originalFontSize;
 
-      if (ratio < 1) {
-        textElement.css("font-size", (originalFontSize * ratio) + "px");
+      while (
+        textElement[0].scrollWidth > target.width() &&
+        fontSize > 1
+      ) {
+        fontSize -= 1;
+        textElement.css("font-size", fontSize + "px");
       }
     } else {
       let scaleX = 1;

--- a/include/globals.js
+++ b/include/globals.js
@@ -319,11 +319,25 @@ function FitText(target) {
     }
 
     textElement.css("transform", "");
-    let scaleX = 1;
+    textElement.css("font-size", "");
 
-    if (textElement[0].scrollWidth * scaleX > target.width()) {
-      scaleX = target.width() / textElement[0].scrollWidth;
-      textElement.css("transform", "scaleX(" + scaleX + ")");
+    if (target.hasClass("font-scale-fit")) {
+      const originalFontSize = parseFloat(
+        window.getComputedStyle(textElement[0]).fontSize
+      );
+
+      const ratio = target.width() / textElement[0].scrollWidth;
+
+      if (ratio < 1) {
+        textElement.css("font-size", (originalFontSize * ratio) + "px");
+      }
+    } else {
+      let scaleX = 1;
+
+      if (textElement[0].scrollWidth * scaleX > target.width()) {
+        scaleX = target.width() / textElement[0].scrollWidth;
+        textElement.css("transform", "scaleX(" + scaleX + ")");
+      }
     }
   });
 }

--- a/include/globals.js
+++ b/include/globals.js
@@ -328,11 +328,13 @@ function FitText(target) {
 
       let fontSize = originalFontSize;
 
+      const targetWidth = target.width();
+
       while (
-        textElement[0].scrollWidth > target.width() &&
+        textElement[0].scrollWidth > targetWidth &&
         fontSize > 1
       ) {
-        fontSize -= 1;
+        fontSize -= 0.1;
         textElement.css("font-size", fontSize + "px");
       }
     } else {


### PR DESCRIPTION
Adding the `font-scale-fit` class to the parent enables this mode.

Normal:
<img width="288" height="200" alt="image" src="https://github.com/user-attachments/assets/17dea754-6550-48bc-bf1c-0507e5c0d3f2" />

`font-scale-fit` mode:
<img width="288" height="192" alt="image" src="https://github.com/user-attachments/assets/58824370-15c9-4825-8d77-332dc18e36cb" />
