### PR TITLE
Derive sponsor colour from score color

### DIFF
--- a/main.css
+++ b/main.css
@@ -188,8 +188,19 @@ img {
 
   /* Player accent colors — defaults; overridden per-match via
      DEFAULT_TEAM1_COLOR / DEFAULT_TEAM2_COLOR in TSHScoreboardWidget.py */
-  --p1-sponsor-color: #ff7a6d;
-  --p2-sponsor-color: #4fc3f7;
+  --p1-sponsor-color: oklch(
+    from var(--p1-score-bg-color)
+    calc(l + 0.13)
+    c
+    h
+  );
+
+  --p2-sponsor-color: oklch(
+    from var(--p2-score-bg-color)
+    calc(l + 0.13)
+    c
+    h
+  );
   --p1-score-bg-color: #e53935;
   --p2-score-bg-color: #1e88e5;
   --p1-score-color: #ffffff;


### PR DESCRIPTION
Comparison between current default sponsor colour vs sponsor colour derived from the current default score color:

<img width="1011" height="409" alt="image" src="https://github.com/user-attachments/assets/0d9a7616-65ee-407e-8be7-138a8cad46f1" />
<img width="1013" height="428" alt="image" src="https://github.com/user-attachments/assets/117202aa-32c0-4eb2-b251-b09521da289f" />

 