### PR TITLE
Skip animations when overlay is not visible

### DIFF
--- a/include/assetUtils.js
+++ b/include/assetUtils.js
@@ -88,6 +88,15 @@ document.addEventListener("tsh_update", (event) => {
     let path = $(e).attr("data-source");
     let data = _.get(event.data, path + ".1.assets");
 
+    if (document.hidden) {
+      gsap.killTweensOf($(e));
+      $(e).css({
+        opacity: data ? 1 : 0,
+        visibility: data ? "inherit" : "hidden",
+      });
+      return;
+    }
+
     if (!data) {
       gsap.timeline().to($(e), { autoAlpha: 0 });
     } else {
@@ -321,11 +330,22 @@ async function updateCharacterContainer(e, event) {
 
       if($(e) && $(e).children(".tsh_character").length > 0){
         anim_out.onComplete = null;
+        if (document.hidden) {
+          gsap.killTweensOf($(e).children(".tsh_character"));
+          $(e).children(".tsh_character").css({
+            opacity: 1,
+            visibility: "inherit",
+          });
+          return;
+        }
         gsap.fromTo($(e).children(".tsh_character"), anim_out, anim_in);
       }
     };
 
-    if (firstRun) {
+    if (document.hidden) {
+      gsap.killTweensOf($(e).children(".tsh_character"));
+      await callback();
+    } else if (firstRun) {
       // No need to fade out
       await callback();
     } else {
@@ -344,6 +364,16 @@ document.addEventListener("tsh_update", (event) => {
   $(".tsh_text").each((i, e) => {
     let path = $(e).attr("data-source");
     let data = _.get(event.data, path);
+
+    if (document.hidden) {
+      gsap.killTweensOf($(e));
+      $(e).css({
+        opacity: data ? 1 : 0,
+        visibility: data ? "inherit" : "hidden",
+      });
+      if (data) SetInnerHtml($(e), data);
+      return;
+    }
 
     if (!data) {
       gsap.timeline().to($(e), { autoAlpha: 0 });

--- a/include/globals.js
+++ b/include/globals.js
@@ -466,6 +466,12 @@ async function SetInnerHtml(element, html, settings = {}) {
         middleFunction();
       }
 
+      if (document.hidden) {
+        gsap.killTweensOf(element.find(".text"));
+        element.find(".text").css({ opacity: 1, visibility: "inherit" });
+        return;
+      }
+
       if (firstRun) {
         gsap.set(element.find(".text"), anim_in);
       } else {
@@ -473,6 +479,11 @@ async function SetInnerHtml(element, html, settings = {}) {
         gsap.fromTo(element.find(".text"), anim_out, anim_in);
       }
     };
+
+    if (document.hidden) {
+      updateElement(element, html, firstRun);
+      return;
+    }
 
     if (!firstRun) {
       anim_out.onComplete = () => updateElement(element, html, firstRun);


### PR DESCRIPTION
This should (hopefully) reduce cases where lots of changes on TSH (e.g loading a new set) when the overlay is hidden or not currently shown in a scene results in some changes not being applied correctly, or results in lots of changes awkwardly fading in at once.

Example:
<img width="912" height="522" alt="doors" src="https://github.com/user-attachments/assets/ace08f8c-c3ed-48f7-9eea-560c0f7c97c1" />

(notice the round name not loading, and all changes awkwardly fading in at once)
